### PR TITLE
Fix "env" object presence in imports

### DIFF
--- a/www/wasmtest.js
+++ b/www/wasmtest.js
@@ -9,7 +9,7 @@ function console_log_ex(location, size) {
 }
 // define our imports
 var imports = {
-    imports: {
+    env: {
         console_log_ex: console_log_ex
     }
 };


### PR DESCRIPTION
I was getting the following error in Chrome and Safari:

`Uncaught (in promise) TypeError: WebAssembly.instantiate(): Import #0 module="env" error: module is not an object or function`

With this small fix things seem to work as expected.