### PR TITLE
Update build.zig as per zig 0.14

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,17 +1,20 @@
 const std = @import("std");
-const Builder = std.build.Builder;
+const Builder = std.Build;
 const builtin = @import("builtin");
 
 pub fn build(b: *Builder) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
     const lib = b.addSharedLibrary(.{
         .name = "wasmtest",
-        .root_source_file = .{.path = "src/main.zig" },
-        .target = .{.cpu_arch = .wasm32, .os_tag = .freestanding},
-        .optimize = .Debug, // you can use the b.standardOptimizeOption(.{}) above this function call instead
-        .version = .{.major = 0, .minor = 0, .patch=1},
-        });
-    lib.rdynamic = true; // by default exports won't be exported so do this to make it all work
-    
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .version = .{ .major = 0, .minor = 0, .patch = 1 },
+    });
+    lib.rdynamic = true;
+
     const install = b.addInstallArtifact(lib, .{});
     install.step.dependOn(&lib.step);
     b.default_step.dependOn(&install.step);


### PR DESCRIPTION
fixes #2 
- Imports: Ensure std.Build is correctly imported.
- Target and Optimization Options: Use b.standardTargetOptions and b.standardOptimizeOption to handle target and optimization settings.
- Library Creation: The addSharedLibrary method and its parameters are set up correctly with the current Zig conventions.
- Dependencies: Ensure the install step depends on the library step.
- Root Source File Path: Use b.path("src/main.zig") to correctly specify the root source file.